### PR TITLE
Fix duplicate platform entry, document missing variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ None.
 history_time_format: true
 systat_logging_enabled: true
 vimrc: true
+epel_repofile_path: "/etc/yum.repos.d/epel.repo"
 disable_neovim_mouse_support: false
 ```
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,9 +12,6 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
-    - name: Ubuntu
-      versions:
-        - all
     - name: Debian
       versions:
         - all


### PR DESCRIPTION
## Summary
- meta/main.yml had a duplicated Ubuntu/all platforms entry (copy-paste stub) - removed
- README Role Variables block was missing epel_repofile_path, which exists in defaults/main.yml and is used in tasks/packages.yml and tasks/assert.yml - added

No functional changes - metadata/docs only.