### PR TITLE
Move ncdu->gdu symlink from /usr/bin to /usr/local/bin

### DIFF
--- a/tasks/gdu.yml
+++ b/tasks/gdu.yml
@@ -13,6 +13,6 @@
 - name: "Ensure ncdu symlinks to gdu"
   ansible.builtin.file:
     src: /usr/bin/gdu
-    dest: /usr/bin/ncdu
+    dest: /usr/local/bin/ncdu
     state: link
   when: "'gdu' in ansible_facts.packages"


### PR DESCRIPTION
## Summary
Fixes #46.

On distros where gdu is available, this role removes the ncdu package and symlinks it to gdu so admins typing ncdu out of habit transparently get gdu instead. The symlink was previously created at /usr/bin/ncdu - a path exclusively owned by the package manager. Dropping an unmanaged symlink there is a packaging-hygiene issue: if anything ever pulls in ncdu as a dependency, apt/dnf can conflict with a file it does not own at that path.

Moved the symlink destination to /usr/local/bin/ncdu, the conventional location for admin-managed binaries not tracked by the package manager. /usr/local/bin already takes PATH precedence over /usr/bin by default on Debian/Ubuntu/RHEL, so the "type ncdu, get gdu" behavior is unchanged for interactive use.

## Test plan
- [ ] On a distro where gdu is installed, confirm /usr/local/bin/ncdu exists as a symlink to /usr/bin/gdu and /usr/bin/ncdu is absent
- [ ] Confirm running \`ncdu\` launches gdu